### PR TITLE
Taks 0: [fix] Fixed the declaration of variables - 5-fmtmod.c file

### DIFF
--- a/5-fmtmod.c
+++ b/5-fmtmod.c
@@ -7,13 +7,11 @@
  */
 int prt_mod(va_list valist)
 {
-	(void) valist;
-
 	int cc;
 	char c = '%';
+	(void) valist;
 
 	cc = 0;
-
 	cc += write(STDOUT_FILENO, &c, 1);
 	return (cc);
 }


### PR DESCRIPTION
I fixed the error with the declarations of variables